### PR TITLE
rename ENABLE_SAFETY_ZONES to ENABLE_SPEED_REGIONS

### DIFF
--- a/deploy_configs.yaml
+++ b/deploy_configs.yaml
@@ -22,7 +22,7 @@ amr_critical_battery_pct: -10.0 # %
 amr_operational_battery_pct: 50.0 # %
 amr_max_battery_pct: 90.0 # %
 amr_charge_time_based: true
-enable_safety_zones: true
+enable_speed_regions: true
 
 # Simulation parameters
 item_spawn_from: AUTO

--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -373,7 +373,7 @@
           MAX_BATTERY_PCT: "{{ amr_max_battery_pct }}"
           CHARGE_TIME_BASED: "{{ amr_charge_time_based }}"
           CHARGE_TIME: "{{ amr_charge_time }}"
-          ENABLE_SAFETY_ZONES: "{{ enable_safety_zones }}"
+          ENABLE_SPEED_REGIONS: "{{ enable_speed_regions }}"
       when: routed_network|bool == false
       loop: "{{  agent_list  }}"
       register: amr_native_id
@@ -407,7 +407,7 @@
           MAX_BATTERY_PCT: "{{ amr_max_battery_pct }}"
           CHARGE_TIME_BASED: "{{ amr_charge_time_based }}"
           CHARGE_TIME: "{{ amr_charge_time }}"
-          ENABLE_SAFETY_ZONES: "{{ enable_safety_zones }}"
+          ENABLE_SPEED_REGIONS: "{{ enable_speed_regions }}"
       when: routed_network|bool == true
       loop: "{{  agent_list  }}"
       register: amr_routed_id


### PR DESCRIPTION
https://www.wrike.com/open.htm?id=750144896

the env variables in the r.io packages will need to be renamed just before the release (not sure when it is planned)
rr_hitachi PR: https://github.com/rapyuta-robotics/rr_hitachi/pull/822