### PR TITLE
Add ROS Bag Job configuraion and topics to control agent mode from RE…

### DIFF
--- a/playbooks/rio_amr_pa_tracing.json
+++ b/playbooks/rio_amr_pa_tracing.json
@@ -362,7 +362,7 @@
             {
               "name":"pa_rosbag",
               "recordOptions":
-                {"allTopics":true}
+                { "topicIncludeRegex": ["dummy_topics"] }
             }
           ]
         }

--- a/playbooks/rio_gbc.json
+++ b/playbooks/rio_gbc.json
@@ -139,6 +139,20 @@
                 "compression": "",
                 "scoped": false,
                 "targeted": false
+              },
+              {
+                "name": "/lbc/set_mode_request",
+                "qos": "low",
+                "compression": "",
+                "scoped": false,
+                "targeted": false
+              },
+              {
+                "name": "/lbc/set_mode_response",
+                "qos": "low",
+                "compression": "",
+                "scoped": false,
+                "targeted": false
               }
             ],
             "services": [

--- a/playbooks/rio_gbc_tracing.json
+++ b/playbooks/rio_gbc_tracing.json
@@ -139,6 +139,20 @@
                 "compression": "",
                 "scoped": false,
                 "targeted": false
+              },
+              {
+                "name": "/lbc/set_mode_request",
+                "qos": "low",
+                "compression": "",
+                "scoped": false,
+                "targeted": false
+              },
+              {
+                "name": "/lbc/set_mode_response",
+                "qos": "low",
+                "compression": "",
+                "scoped": false,
+                "targeted": false
               }
             ],
             "services": [
@@ -222,7 +236,7 @@
             {
               "name":"gbc_rosbag",
               "recordOptions":
-                {"allTopics":true}
+                { "topicIncludeRegex": ["dummy_topics"] }
             }
           ]
         }


### PR DESCRIPTION
The topics "/lbc/set_mode_request" and "/lbc/set_mode_response" are added to control agent mode from REST API.
The configuration "allTopics":true will record too much logs, so a dummy configuration to show ROS Bag Jobs tab on Rapyuta.io is added.
