### PR TITLE
remove GBC deployment in ansible depending on Postgres

### DIFF
--- a/playbooks/deploy.yaml
+++ b/playbooks/deploy.yaml
@@ -237,7 +237,6 @@
         package_name: rio_gbc
         depends:
           deployments:
-            - "{{ prefix_name }}_postgres"
             - "{{ prefix_name }}_rr_gwm"
         networks:
           static_routes:
@@ -264,7 +263,6 @@
         package_name: rio_gbc
         depends:
           deployments:
-            - "{{ prefix_name }}_postgres"
             - "{{ prefix_name }}_rr_gwm"
         networks:
           static_routes:


### PR DESCRIPTION
Removed the dependency on Postgres for GBC deployment modules